### PR TITLE
Pla 8719 missing rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Show violation results
          | cloud id| --cloud-id| VMware Secure State cloud id of which account you'd like to show violation for, this flag is optional|
          | severity | --severity | The severity level you'd like to show in violation results |
          | retry | --retry | Retry times when getting violation fails |
-    * By default you will get all violation objects under your account, three flag filters are provided: team-id, cloud-id and severity
+    * By default you will get all violation objects under your team, three flag filters are provided: team-id, cloud-id and severity. If team-id is not specified, the team in your profile will be automatically loaded.
     * Examples
          * `vss result object --severity "High|Medium"`    
          * `vss result object --severity "High|Low"`  
@@ -282,7 +282,7 @@ Show violation results
         | ------ | ------ | :-------- |
         | cloud account| --cloud-account-id| VMware Secure State cloud id of which account you'd like to show violation for, this flag is optional|
         | severity | --severity | The severity level you'd like to show in violation results |
-    * By default you will get all violation rules under your account, three flag filters are provided: team-id, cloud-id and severity
+    * By default you will get all violation rules under your team, three flag filters are provided: team-id, cloud-id and severity. If team-id is not specified, the team in your profile will be automatically loaded.
     * Examples
         * `vss result rule --severity "High|Medium"`
         * `vss result rule --severity "High|Low"`

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Show violation results
          | cloud id| --cloud-id| VMware Secure State cloud id of which account you'd like to show violation for, this flag is optional|
          | severity | --severity | The severity level you'd like to show in violation results |
          | retry | --retry | Retry times when getting violation fails |
-    * By default you will get all violation objects under your team, three flag filters are provided: team-id, cloud-id and severity. If team-id is not specified, the team in your profile will be automatically loaded.
+    * By default you will get all violation objects under your team, three flag filters are provided: team-id, cloud-id and severity. If team-id is not specified, the team in your profile will be automatically used.
     * Examples
          * `vss result object --severity "High|Medium"`    
          * `vss result object --severity "High|Low"`  
@@ -282,7 +282,7 @@ Show violation results
         | ------ | ------ | :-------- |
         | cloud account| --cloud-account-id| VMware Secure State cloud id of which account you'd like to show violation for, this flag is optional|
         | severity | --severity | The severity level you'd like to show in violation results |
-    * By default you will get all violation rules under your team, three flag filters are provided: team-id, cloud-id and severity. If team-id is not specified, the team in your profile will be automatically loaded.
+    * By default you will get all violation rules under your team, three flag filters are provided: team-id, cloud-id and severity. If team-id is not specified, the team in your profile will be automatically used.
     * Examples
         * `vss result rule --severity "High|Medium"`
         * `vss result rule --severity "High|Low"`

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Build instructions are as follows (see [install golang](https://docs.minio.io/do
 ## Getting started
 Get your access keys on [VMware CSP User Portal](https://console.cloud.vmware.com/csp/gateway/portal/#/user/tokens).
 
-You use API tokens to authenticate yourself when you make authorized API connections. Previously called an OAuth Refresh token, an API token authorizes access per organization.
+You use API tokens to authenticate yourself when you make authorized API connections. An API token authorizes access per organization.
 
 You can generate more than one API token. A token is valid for six months, after which time you must regenerate it if you want to continue using APIs that rely on a token. If you feel the token has been compromised, you can revoke the token to prevent unauthorized access. You generate a new token to renew authorization.
 
@@ -78,7 +78,7 @@ Procedure
 You may need to configure your access key and default team id the first time using CLI but you can also skip this step and pass these to CLI using flags `--api-key, --team-id`. You may set up configuration using:
 	`vss  configure`
 	
-And then type you access key information and default team id as well. You may check you current configuration settings using
+And then type your access key information and default team id as well. You may check you current configuration settings using
 	`vss configure list`
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The most commonly used VSS commands are:
 ## Configurable variables
 |Variable | Option | Environment Variable | Description |
 | ------ | ------ | :--------:| :-------- |
-|api-key | --api-key| |Vss API Token, will read api-key in configure file by default| 
+|api-key | --api-key| |VSS API Token, will read api-key in configure file by default| 
 |endpoint| --endpoint |$VSS_API_ENDPOINT| VSS API endpoint, default https://app.securestate.vmware.com/api |
 |help    | --help, -h| | Get user manual for command
 |home    | --home | $VSS_HOME | Location of your VSS config. Overrides $VSS_HOME.

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Use CLI to...
 
 ### OSX
 
-Download `vss` from [https://github.com/CloudCoreo/cli/releases/download/v0.0.37/vss_darwin_amd64](https://github.com/CloudCoreo/cli/releases/download/v0.0.37/vss_darwin_amd64)
+Download `vss` from [https://github.com/CloudCoreo/cli/releases/download/v0.0.38/vss_darwin_amd64](https://github.com/CloudCoreo/cli/releases/download/v0.0.38/vss_darwin_amd64)
 
 ```sh
  mkdir vss && cd vss
- wget -q -O vss https://github.com/CloudCoreo/cli/releases/download/v0.0.37/vss_darwin_amd64
+ wget -q -O vss https://github.com/CloudCoreo/cli/releases/download/v0.0.38/vss_darwin_amd64
  chmod +x vss
  export PATH=$PATH:${PWD}   # Add current dir where vss has been downloaded to
  vss
@@ -29,11 +29,11 @@ Download `vss` from [https://github.com/CloudCoreo/cli/releases/download/v0.0.37
 
 ### Linux
 
-Download `vss` from [https://github.com/CloudCoreo/cli/releases/download/v0.0.37/vss_linux_amd64](https://github.com/CloudCoreo/cli/releases/download/v0.0.37/vss_linux_amd64)
+Download `vss` from [https://github.com/CloudCoreo/cli/releases/download/v0.0.38/vss_linux_amd64](https://github.com/CloudCoreo/cli/releases/download/v0.0.38/vss_linux_amd64)
 
 ```sh
  mkdir vss && cd vss
- wget -q -O vss https://github.com/CloudCoreo/cli/releases/download/v0.0.37/vss_linux_amd64
+ wget -q -O vss https://github.com/CloudCoreo/cli/releases/download/v0.0.38/vss_linux_amd64
  chmod +x vss
  export PATH=$PATH:${PWD}   # Add current dir where vss has been downloaded to
  vss
@@ -41,7 +41,7 @@ Download `vss` from [https://github.com/CloudCoreo/cli/releases/download/v0.0.37
 
 ### Windows
 
-Download `vss.exe` from [https://github.com/CloudCoreo/cli/releases/download/v0.0.37/vss_windows_amd64.exe](https://github.com/CloudCoreo/cli/releases/download/v0.0.37/vss_windows_amd64.exe)
+Download `vss.exe` from [https://github.com/CloudCoreo/cli/releases/download/v0.0.38/vss_windows_amd64.exe](https://github.com/CloudCoreo/cli/releases/download/v0.0.38/vss_windows_amd64.exe)
 
 ```
 C:\Users\Username\Downloads> rename vss_windows_amd64.exe vss.exe
@@ -62,10 +62,20 @@ Build instructions are as follows (see [install golang](https://docs.minio.io/do
  vss
 ```
 ## Getting started
-Get your access keys on [VMware Secure State](https://app.securestate.vmware.com/main/settings/cli).
-Go to the “Settings” menu and select the "Command-Line Interface”, then click the “Create Access Key” button. Your default team id is right below the access key id window.  
+Get your access keys on [VMware CSP User Portal](https://console.cloud.vmware.com/csp/gateway/portal/#/user/tokens).
 
-You may need to configure your access key and default team id the first time using CLI but you can also skip this step and pass these to CLI using flags `--api-key, --api-secret, --team-id`. You may set up configuration using:
+You use API tokens to authenticate yourself when you make authorized API connections. Previously called an OAuth Refresh token, an API token authorizes access per organization.
+
+You can generate more than one API token. A token is valid for six months, after which time you must regenerate it if you want to continue using APIs that rely on a token. If you feel the token has been compromised, you can revoke the token to prevent unauthorized access. You generate a new token to renew authorization.
+
+Procedure
+1. On the VMware Cloud Services toolbar, click your user name and select My Account > API Tokens.
+2. Click New Token.
+3. Click Copy to Clipboard.
+4. Paste the token in a safe place so you can retrieve it to use later on.
+
+
+You may need to configure your access key and default team id the first time using CLI but you can also skip this step and pass these to CLI using flags `--api-key, --team-id`. You may set up configuration using:
 	`vss  configure`
 	
 And then type you access key information and default team id as well. You may check you current configuration settings using
@@ -95,8 +105,7 @@ The most commonly used VSS commands are:
 ## Configurable variables
 |Variable | Option | Environment Variable | Description |
 | ------ | ------ | :--------:| :-------- |
-|api-key | --api-key| |Vss API Key, will read api-key in configure file by default| 
-|api-secret |--api-secret | |Vss API Secret, will read api-secret in configure file by default|
+|api-key | --api-key| |Vss API Token, will read api-key in configure file by default| 
 |endpoint| --endpoint |$VSS_API_ENDPOINT| VSS API endpoint, default https://app.securestate.vmware.com/api |
 |help    | --help, -h| | Get user manual for command
 |home    | --home | $VSS_HOME | Location of your VSS config. Overrides $VSS_HOME.
@@ -223,7 +232,7 @@ Configure CLI options
     * `vss configure list` &nbsp; : list current configuration
 * Examples
     * `vss configure`
-    * `vss configure --api-key VSS_API_KEY --api-secret VSS_API_SECRET --team-id VSS_TEAM_ID`
+    * `vss configure --api-key VSS_API_TOKEN --team-id VSS_TEAM_ID`
     * `vss configure list`
     
 #### team

--- a/client/auth.go
+++ b/client/auth.go
@@ -72,11 +72,11 @@ func (a *Auth) getCspAuthToken() (*cspToken, error) {
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Content-Length", strconv.Itoa(len(data.Encode())))
 	resp, err := http.DefaultClient.Do(req)
-	defer resp.Body.Close()
-
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
+
 	if resp.StatusCode >= 300 {
 		message := new(bytes.Buffer)
 		message.ReadFrom(resp.Body)

--- a/client/client.go
+++ b/client/client.go
@@ -55,13 +55,13 @@ type Client struct {
 }
 
 // MakeClient make client
-func MakeClient(apiKey, secretKey, endpoint string) (*Client, error) {
+func MakeClient(refreshToken, endpoint string) (*Client, error) {
 
-	if apiKey == "None" || secretKey == "None" || apiKey == "" || secretKey == "" {
+	if refreshToken == "None" || refreshToken == "" {
 		return nil, NewError(content.ErrorMissingAPIOrSecretKey)
 	}
 
-	a := Auth{APIKey: apiKey, SecretKey: secretKey}
+	a := Auth{RefreshToken: refreshToken}
 	i := Interceptor(a.SignRequest)
 	c := newClient(endpoint, WithInterceptor(i))
 

--- a/client/client.go
+++ b/client/client.go
@@ -85,12 +85,8 @@ func newClient(endpoint string, opts ...Option) *Client {
 // Do performs an HTTP request with a given context - the response will be decoded
 // into obj.
 func (c *Client) Do(ctx context.Context, method, path string, body io.Reader, obj interface{}) error {
-	req, err := c.buildRequest(method, path, body)
-	if err != nil {
-		return err
-	}
 
-	resp, err := ctxhttp.Do(ctx, &c.client, req)
+	resp, err := c.makeRequest(ctx, method, path, body)
 	if err != nil {
 		return err
 	}
@@ -114,6 +110,14 @@ func (c *Client) Do(ctx context.Context, method, path string, body io.Reader, ob
 	io.Copy(ioutil.Discard, resp.Body)
 
 	return err
+}
+
+func (c *Client) makeRequest(ctx context.Context, method, path string, body io.Reader) (*http.Response, error) {
+	req, err := c.buildRequest(method, path, body)
+	if err != nil {
+		return nil, err
+	}
+	return ctxhttp.Do(ctx, &c.client, req)
 }
 
 func (c *Client) buildRequest(method, urlPath string, body io.Reader) (*http.Request, error) {

--- a/client/cloudAccount.go
+++ b/client/cloudAccount.go
@@ -367,6 +367,12 @@ func (t *UpdateCloudAccountInput) mergeAndGetJson(account *CloudAccount) ([]byte
 	updateInfo.IsDraft = t.IsDraft
 	// Add teamID to pass webapp check for cloud account creation
 	updateInfo.TeamID = t.TeamID
+	if t.Environment != "" {
+		updateInfo.Environment = []string{t.Environment}
+	}
+	if t.Tags != "" {
+		updateInfo.Tags = strings.Split(t.Tags, "|")
+	}
 	jsonStr, err := json.Marshal(updateInfo)
 	if err != nil {
 		return nil, err
@@ -385,11 +391,13 @@ func (t *UpdateCloudAccountInput) toCloudPayLoad() *CloudPayLoad {
 			ScanRegion:   "All",
 			ExternalID:   t.ExternalID,
 			IsDraft:      t.IsDraft,
-			Provider:     t.Provider,
 			Email:        t.Email,
 			UserName:     t.UserName,
 			Environment:  []string{t.Environment},
 		},
+	}
+	if t.Tags != "" {
+		cloudPayLoad.Tags = strings.Split(t.Tags, "|")
 	}
 	return cloudPayLoad
 }

--- a/client/cloudAccount.go
+++ b/client/cloudAccount.go
@@ -384,20 +384,20 @@ func (t *UpdateCloudAccountInput) mergeAndGetJson(account *CloudAccount) ([]byte
 func (t *UpdateCloudAccountInput) toCloudPayLoad() *CloudPayLoad {
 	cloudPayLoad := &CloudPayLoad{
 		CloudInfo: CloudInfo{
-			Name:         t.CloudName,
-			Arn:          t.RoleArn,
-			ScanEnabled:  t.ScanEnabled,
-			ScanInterval: "Daily",
-			ScanRegion:   "All",
-			ExternalID:   t.ExternalID,
-			IsDraft:      t.IsDraft,
-			Email:        t.Email,
-			UserName:     t.UserName,
-			Environment:  []string{t.Environment},
+			Name:           t.CloudName,
+			Arn:            t.RoleArn,
+			ScanEnabled:    t.ScanEnabled,
+			ScanInterval:   "Daily",
+			ScanRegion:     "All",
+			ExternalID:     t.ExternalID,
+			IsDraft:        t.IsDraft,
+			Email:          t.Email,
+			UserName:       t.UserName,
+			SubscriptionID: t.SubscriptionID,
+			KeyValue:       t.KeyValue,
+			ApplicationID:  t.ApplicationID,
+			DirectoryID:    t.DirectoryID,
 		},
-	}
-	if t.Tags != "" {
-		cloudPayLoad.Tags = strings.Split(t.Tags, "|")
 	}
 	return cloudPayLoad
 }
@@ -405,17 +405,22 @@ func (t *UpdateCloudAccountInput) toCloudPayLoad() *CloudPayLoad {
 func (t *CloudAccount) toCloudPayLoad() *CloudPayLoad {
 	cloudPayLoad := &CloudPayLoad{
 		CloudInfo: CloudInfo{
-			Name:         t.Name,
-			Arn:          t.Arn,
-			ScanEnabled:  t.ScanEnabled,
-			ScanInterval: t.ScanInterval,
-			ScanRegion:   t.ScanRegion,
-			ExternalID:   t.ExternalID,
-			IsDraft:      t.IsDraft,
-			Provider:     t.Provider,
-			Email:        t.Email,
-			UserName:     t.UserName,
-			Environment:  t.Environment,
+			Name:           t.Name,
+			Arn:            t.Arn,
+			ScanEnabled:    t.ScanEnabled,
+			ScanInterval:   t.ScanInterval,
+			ScanRegion:     t.ScanRegion,
+			ExternalID:     t.ExternalID,
+			IsDraft:        t.IsDraft,
+			Provider:       t.Provider,
+			Email:          t.Email,
+			UserName:       t.UserName,
+			Environment:    t.Environment,
+			SubscriptionID: t.SubscriptionID,
+			KeyValue:       t.KeyValue,
+			ApplicationID:  t.ApplicationID,
+			DirectoryID:    t.DirectoryID,
+			Tags:           t.Tags,
 		},
 	}
 	return cloudPayLoad

--- a/cmd/cloudAccount.go
+++ b/cmd/cloudAccount.go
@@ -66,8 +66,7 @@ func newCloudListCmd(client command.Interface, out io.Writer) *cobra.Command {
 			if cloudList.client == nil {
 				cloudList.client = coreo.NewClient(
 					coreo.Host(apiEndpoint),
-					coreo.APIKey(key),
-					coreo.SecretKey(secret))
+					coreo.RefreshToken(key))
 			}
 
 			cloudList.teamID = teamID
@@ -133,8 +132,7 @@ func newCloudTestCmd(client command.Interface, out io.Writer) *cobra.Command {
 			if cloudTest.client == nil {
 				cloudTest.client = coreo.NewClient(
 					coreo.Host(apiEndpoint),
-					coreo.APIKey(key),
-					coreo.SecretKey(secret))
+					coreo.RefreshToken(key))
 			}
 
 			cloudTest.teamID = teamID

--- a/cmd/cloudAccount_create.go
+++ b/cmd/cloudAccount_create.go
@@ -84,8 +84,7 @@ func newCloudCreateCmd(client command.Interface, out io.Writer) *cobra.Command {
 			if cloudCreate.client == nil {
 				cloudCreate.client = coreo.NewClient(
 					coreo.Host(apiEndpoint),
-					coreo.APIKey(key),
-					coreo.SecretKey(secret))
+					coreo.RefreshToken(key))
 			}
 
 			if cloudCreate.cloud == nil {

--- a/cmd/cloudAccount_delete.go
+++ b/cmd/cloudAccount_delete.go
@@ -60,8 +60,7 @@ func newCloudDeleteCmd(client command.Interface, out io.Writer) *cobra.Command {
 			if cloudDelete.client == nil {
 				cloudDelete.client = coreo.NewClient(
 					coreo.Host(apiEndpoint),
-					coreo.APIKey(key),
-					coreo.SecretKey(secret))
+					coreo.RefreshToken(key))
 			}
 
 			if cloudDelete.deleteRole && (cloudDelete.cloud == nil) {

--- a/cmd/cloudAccount_scan.go
+++ b/cmd/cloudAccount_scan.go
@@ -41,8 +41,7 @@ func newCloudScanCmd(client command.Interface, out io.Writer) *cobra.Command {
 			if cloudScan.client == nil {
 				cloudScan.client = coreo.NewClient(
 					coreo.Host(apiEndpoint),
-					coreo.APIKey(key),
-					coreo.SecretKey(secret))
+					coreo.RefreshToken(key))
 			}
 
 			if cloudScan.cloud == nil {

--- a/cmd/cloudAccount_show.go
+++ b/cmd/cloudAccount_show.go
@@ -51,8 +51,7 @@ func newCloudShowCmd(client command.Interface, out io.Writer) *cobra.Command {
 			if cloudShow.client == nil {
 				cloudShow.client = coreo.NewClient(
 					coreo.Host(apiEndpoint),
-					coreo.APIKey(key),
-					coreo.SecretKey(secret))
+					coreo.RefreshToken(key))
 			}
 
 			cloudShow.teamID = teamID

--- a/cmd/cloudAccount_update.go
+++ b/cmd/cloudAccount_update.go
@@ -56,8 +56,7 @@ func newCloudUpdateCmd(client command.Interface, out io.Writer) *cobra.Command {
 			if cloudUpdate.client == nil {
 				cloudUpdate.client = coreo.NewClient(
 					coreo.Host(apiEndpoint),
-					coreo.APIKey(key),
-					coreo.SecretKey(secret))
+					coreo.RefreshToken(key))
 			}
 
 			if cloudUpdate.cloud == nil {

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -58,26 +58,21 @@ func (t *configureCmd) run() error {
 
 	//generate config keys based on user profile
 	apiKey := fmt.Sprintf("%s.%s", userProfile, content.AccessKey)
-	secretKey := fmt.Sprintf("%s.%s", userProfile, content.SecretKey)
 	teamIDKey := fmt.Sprintf("%s.%s", userProfile, content.TeamID)
 
 	userAPIkey := ""
-	userSecretKey := ""
 	userTeamID := ""
 
 	// load from config
 	apiKeyValue := util.GetValueFromConfig(apiKey, true)
-	secretKeyValue := util.GetValueFromConfig(secretKey, true)
 	teamIDValue := util.GetValueFromConfig(teamIDKey, false)
 
 	// prompt user for input
 	setValue(&userAPIkey, key, fmt.Sprintf(content.CmdConfigurePromptAPIKEY, apiKeyValue))
-	setValue(&userSecretKey, secret, fmt.Sprintf(content.CmdConfigurePromptSecretKEY, secretKeyValue))
 	setValue(&userTeamID, teamID, fmt.Sprintf(content.CmdConfigurePromptTeamID, teamIDValue))
 
 	// replace values in config
 	util.UpdateConfig(apiKey, userAPIkey)
-	util.UpdateConfig(secretKey, userSecretKey)
 	util.UpdateConfig(teamIDKey, userTeamID)
 
 	// save config

--- a/cmd/configure_list.go
+++ b/cmd/configure_list.go
@@ -69,13 +69,11 @@ func (t *configureListCmd) run() error {
 
 		//generate config keys based on user profile
 		apiKey := fmt.Sprintf("%s.%s", k, content.AccessKey)
-		secretKey := fmt.Sprintf("%s.%s", k, content.SecretKey)
 		teamIDKey := fmt.Sprintf("%s.%s", k, content.TeamID)
 
 		profile := &Profile{
 			ProfileName: k,
 			APIKey:      util.GetValueFromConfig(apiKey, true),
-			SecretKey:   util.GetValueFromConfig(secretKey, true),
 			TeamID:      util.GetValueFromConfig(teamIDKey, false),
 		}
 

--- a/cmd/content/root.go
+++ b/cmd/content/root.go
@@ -18,9 +18,6 @@ const (
 	//AccessKey api key
 	AccessKey = "API_KEY"
 
-	//SecretKey secret key
-	SecretKey = "SECRET_KEY"
-
 	//TeamID team id
 	TeamID = "TEAM_ID"
 

--- a/cmd/coreo.go
+++ b/cmd/coreo.go
@@ -38,7 +38,6 @@ var (
 	coreoHome   string
 	userProfile string
 	key         string
-	secret      string
 	teamID      string
 	apiEndpoint string
 	jsonFormat  bool
@@ -69,7 +68,6 @@ func newRootCmd(out io.Writer) *cobra.Command {
 	p.StringVar(&coreoHome, content.CmdFlagConfigLong, defaultCoreoHome(), content.CmdFlagConfigDescription)
 	p.StringVar(&userProfile, content.CmdFlagProfileLong, userProfileToUse, content.CmdFlagProfileDescription)
 	p.StringVar(&key, content.CmdFlagAPIKeyLong, content.None, content.CmdFlagAPIKeyDescription)
-	p.StringVar(&secret, content.CmdFlagAPISecretLong, content.None, content.CmdFlagAPISecretDescription)
 	p.StringVar(&teamID, content.CmdFlagTeamIDLong, content.None, content.CmdFlagTeamIDDescription)
 	p.StringVar(&apiEndpoint, content.CmdFlagAPIEndpointLong, envAPIEndpoint, content.CmdFlagAPIEndpointDescription)
 	p.BoolVar(&jsonFormat, content.CmdFlagJSONLong, false, content.CmdFlagJSONDescription)
@@ -144,13 +142,6 @@ func setupCoreoCredentials(cmd *cobra.Command, args []string) error {
 
 	}
 	key = apiKey
-
-	secretKey, err := util.CheckSecretKeyFlag(secret, userProfile)
-
-	if err != nil {
-		return err
-	}
-	secret = secretKey
 
 	if verbose {
 		fmt.Printf(content.InfoUsingProfile, userProfile)

--- a/cmd/coreo_test.go
+++ b/cmd/coreo_test.go
@@ -107,7 +107,7 @@ func (c *fakeReleaseClient) DeleteCloudAccountByID(teamID, cloudID string) error
 	return c.err
 }
 
-func (c *fakeReleaseClient) ShowResultRule(teamID, cloudID, level string) ([]*client.ResultRule, error) {
+func (c *fakeReleaseClient) ShowResultRule(teamID, cloudID, level, provider string) ([]*client.ResultRule, error) {
 	resp := c.rules
 	return resp, c.err
 }

--- a/cmd/event_remove.go
+++ b/cmd/event_remove.go
@@ -53,8 +53,7 @@ func newEventRemoveCmd(client command.Interface, provider command.CloudProvider,
 			if eventRemove.client == nil {
 				eventRemove.client = coreo.NewClient(
 					coreo.Host(apiEndpoint),
-					coreo.APIKey(key),
-					coreo.SecretKey(secret))
+					coreo.RefreshToken(key))
 			}
 
 			eventRemove.teamID = teamID

--- a/cmd/event_setup.go
+++ b/cmd/event_setup.go
@@ -50,8 +50,7 @@ func newEventSetupCmd(client command.Interface, provider command.CloudProvider, 
 			if eventSetup.client == nil {
 				eventSetup.client = coreo.NewClient(
 					coreo.Host(apiEndpoint),
-					coreo.APIKey(key),
-					coreo.SecretKey(secret))
+					coreo.RefreshToken(key))
 			}
 
 			eventSetup.teamID = teamID

--- a/cmd/result.go
+++ b/cmd/result.go
@@ -28,7 +28,7 @@ func newResultCmd(out io.Writer) *cobra.Command {
 		Use:               content.CmdResultUse,
 		Short:             content.CmdResultShort,
 		Long:              content.CmdResultLong,
-		PersistentPreRunE: setupCoreoCredentials,
+		PersistentPreRunE: setupCoreoConfig,
 	}
 
 	cmd.AddCommand(newResultRuleCmd(nil, out))

--- a/cmd/result_object.go
+++ b/cmd/result_object.go
@@ -40,9 +40,9 @@ type resultObjectCmd struct {
 type Object struct {
 	ID string `json:"objectName"`
 	client.Info
-
-	RiskScore int             `json:"riskScore"`
-	TInfo     client.TeamInfo `json:"team"`
+	RiskScore int    `json:"riskScore"`
+	TeamName  string `json:"teamName"`
+	TeamID    string `json:"teamID"`
 }
 
 type ObjectWrapper struct {
@@ -98,7 +98,8 @@ func (t *resultObjectCmd) prettyPrintObjects(wrappers []*client.ResultObjectWrap
 		result[i].TotalItems = wrapper.TotalItems
 		result[i].Objects = make([]Object, len(wrapper.Objects))
 		for j, object := range wrapper.Objects {
-			result[i].Objects[j].TInfo = object.TInfo
+			result[i].Objects[j].TeamName = object.TInfo.Name
+			result[i].Objects[j].TeamID = object.TInfo.ID
 			result[i].Objects[j].RiskScore = object.RiskScore
 			result[i].Objects[j].ID = object.ID
 			result[i].Objects[j].Info = object.Info

--- a/cmd/result_object.go
+++ b/cmd/result_object.go
@@ -66,8 +66,7 @@ func newResultObjectCmd(client command.Interface, out io.Writer) *cobra.Command 
 			if resultObject.client == nil {
 				resultObject.client = coreo.NewClient(
 					coreo.Host(apiEndpoint),
-					coreo.APIKey(key),
-					coreo.SecretKey(secret))
+					coreo.RefreshToken(key))
 			}
 
 			resultObject.teamID = teamID

--- a/cmd/result_object_test.go
+++ b/cmd/result_object_test.go
@@ -26,10 +26,8 @@ const kmsKeyRotatesObjectOutput = `[
 				"include_violations_in_count": true,
 				"timestamp": "2018-10-11T17:21:55.111+00:00",
 				"riskScore": 0,
-				"team": {
-					"name": "fake-team-name",
-					"id": "fake-team-id"
-				}
+				"teamName": "fake-team-name",
+				"teamID": "fake-team-id"
 			}
 		]
 	}
@@ -53,10 +51,8 @@ const iamInactiveKeyNoRotationObjectOutput = `[
 				"include_violations_in_count": true,
 				"timestamp": "2018-10-11T17:21:54.448+00:00",
 				"riskScore": 0,
-				"team": {
-					"name": "fake-team-name",
-					"id": "fake-team-id"
-				}
+				"teamName": "fake-team-name",
+				"teamID": "fake-team-id"
 			}
 		]
 	}

--- a/cmd/result_rule.go
+++ b/cmd/result_rule.go
@@ -48,8 +48,7 @@ func newResultRuleCmd(client command.Interface, out io.Writer) *cobra.Command {
 			if resultRule.client == nil {
 				resultRule.client = coreo.NewClient(
 					coreo.Host(apiEndpoint),
-					coreo.APIKey(key),
-					coreo.SecretKey(secret))
+					coreo.RefreshToken(key))
 			}
 
 			resultRule.teamID = teamID

--- a/cmd/result_rule.go
+++ b/cmd/result_rule.go
@@ -26,11 +26,12 @@ import (
 )
 
 type resultRuleCmd struct {
-	client  command.Interface
-	teamID  string
-	cloudID string
-	out     io.Writer
-	level   string
+	client   command.Interface
+	teamID   string
+	cloudID  string
+	out      io.Writer
+	level    string
+	provider string
 }
 
 func newResultRuleCmd(client command.Interface, out io.Writer) *cobra.Command {
@@ -59,11 +60,12 @@ func newResultRuleCmd(client command.Interface, out io.Writer) *cobra.Command {
 	f := cmd.Flags()
 	f.StringVar(&resultRule.cloudID, content.CmdFlagCloudAccountID, content.None, content.CmdFlagCloudAccountIDDescription)
 	f.StringVar(&resultRule.level, content.CmdFlagLevelLong, "", content.CmdFlagLevelDescription)
+	f.StringVar(&resultRule.provider, content.CmdFlagProvider, "", content.CmdFlagProviderDescription)
 	return cmd
 }
 
 func (t *resultRuleCmd) run() error {
-	res, err := t.client.ShowResultRule(t.teamID, t.cloudID, t.level)
+	res, err := t.client.ShowResultRule(t.teamID, t.cloudID, t.level, t.provider)
 	if err != nil {
 		return err
 	}

--- a/cmd/team.go
+++ b/cmd/team.go
@@ -61,8 +61,7 @@ func newTeamListCmd(client command.Interface, out io.Writer) *cobra.Command {
 			if teamList.client == nil {
 				teamList.client = coreo.NewClient(
 					coreo.Host(apiEndpoint),
-					coreo.APIKey(key),
-					coreo.SecretKey(secret))
+					coreo.RefreshToken(key))
 			}
 
 			return teamList.run()

--- a/cmd/team_create.go
+++ b/cmd/team_create.go
@@ -50,8 +50,7 @@ func newTeamCreateCmd(client command.Interface, out io.Writer) *cobra.Command {
 			if teamCreate.client == nil {
 				teamCreate.client = coreo.NewClient(
 					coreo.Host(apiEndpoint),
-					coreo.APIKey(key),
-					coreo.SecretKey(secret))
+					coreo.RefreshToken(key))
 			}
 
 			return teamCreate.run()

--- a/cmd/team_show.go
+++ b/cmd/team_show.go
@@ -45,8 +45,7 @@ func newTeamShowCmd(client command.Interface, out io.Writer) *cobra.Command {
 			if teamShow.client == nil {
 				teamShow.client = coreo.NewClient(
 					coreo.Host(apiEndpoint),
-					coreo.APIKey(key),
-					coreo.SecretKey(secret))
+					coreo.RefreshToken(key))
 			}
 
 			teamShow.teamID = teamID

--- a/cmd/token.go
+++ b/cmd/token.go
@@ -59,8 +59,7 @@ func newTokenListCmd(client command.Interface, out io.Writer) *cobra.Command {
 			if tokenList.client == nil {
 				tokenList.client = coreo.NewClient(
 					coreo.Host(apiEndpoint),
-					coreo.APIKey(key),
-					coreo.SecretKey(secret))
+					coreo.RefreshToken(key))
 			}
 
 			return tokenList.run()

--- a/cmd/token_delete.go
+++ b/cmd/token_delete.go
@@ -51,8 +51,7 @@ func newTokenDeleteCmd(client command.Interface, out io.Writer) *cobra.Command {
 			if tokenDelete.client == nil {
 				tokenDelete.client = coreo.NewClient(
 					coreo.Host(apiEndpoint),
-					coreo.APIKey(key),
-					coreo.SecretKey(secret))
+					coreo.RefreshToken(key))
 			}
 
 			return tokenDelete.run()

--- a/cmd/token_show.go
+++ b/cmd/token_show.go
@@ -49,8 +49,7 @@ func newTokenShowCmd(client command.Interface, out io.Writer) *cobra.Command {
 			if tokenShow.client == nil {
 				tokenShow.client = coreo.NewClient(
 					coreo.Host(apiEndpoint),
-					coreo.APIKey(key),
-					coreo.SecretKey(secret))
+					coreo.RefreshToken(key))
 			}
 
 			return tokenShow.run()

--- a/cmd/util/flags.go
+++ b/cmd/util/flags.go
@@ -139,20 +139,6 @@ func CheckAPIKeyFlag(apiKey string, userProfile string) (string, error) {
 	return apiKey, nil
 }
 
-// CheckSecretKeyFlag flag check for secret key
-func CheckSecretKeyFlag(secretKey string, userProfile string) (string, error) {
-	if secretKey == content.None {
-		secretIDKey := fmt.Sprintf("%s.%s", userProfile, content.SecretKey)
-		secretKey = GetValueFromConfig(secretIDKey, false)
-
-		if secretKey == content.None {
-			return secretKey, fmt.Errorf(content.ErrorAPISecretMissing)
-		}
-	}
-
-	return secretKey, nil
-}
-
 //CheckTeamAddFlags Required flags check
 func CheckTeamAddFlags(teamName, teamDescription string) error {
 	if err := checkFlag(teamName, content.ErrorTeamNameRequired); err != nil {

--- a/cmd/util/flags_test.go
+++ b/cmd/util/flags_test.go
@@ -53,18 +53,6 @@ func TestCheckAPIKeyFlagFailure(t *testing.T) {
 	assert.Equal(t, content.ErrorAPIKeyMissing, err.Error())
 }
 
-func TestCheckSecretKeyFlagSuccess(t *testing.T) {
-	res, err := CheckSecretKeyFlag("api-secret", "default")
-	assert.Nil(t, err, "TestCheckSecretKeyFlagSuccess shouldn't return error")
-	assert.Equal(t, "api-secret", res)
-}
-
-func TestCheckSecretKeyFlagFailure(t *testing.T) {
-	_, err := CheckSecretKeyFlag("None", "invalid")
-	assert.NotNil(t, err, "TestCheckSecretKeyFlagFailure should return error")
-	assert.Equal(t, content.ErrorAPISecretMissing, err.Error())
-}
-
 func TestCheckTeamAddFlagsSuccess(t *testing.T) {
 	err := CheckTeamAddFlags("teamName", "teamDescription")
 	assert.Nil(t, err, "TestCheckTeamAddFlagsSuccess shouldn't return error")

--- a/pkg/command/interface.go
+++ b/pkg/command/interface.go
@@ -34,7 +34,7 @@ type Interface interface {
 	ReValidateRole(teamID, cloudID string) (*client.RoleReValidationResult, error)
 
 	ShowResultObject(teamID, cloudID, level, provider string, retry uint) ([]*client.ResultObjectWrapper, error)
-	ShowResultRule(teamID, cloudID, level string) ([]*client.ResultRule, error)
+	ShowResultRule(teamID, cloudID, level, provider string) ([]*client.ResultRule, error)
 
 	GetEventStreamConfig(teamID, cloudID string) (*client.EventStreamConfig, error)
 	GetEventRemoveConfig(teamID, cloudID string) (*client.EventRemoveConfig, error)

--- a/pkg/coreo/client.go
+++ b/pkg/coreo/client.go
@@ -232,7 +232,7 @@ func (c *Client) ReValidateRole(teamID, cloudID string) (*client.RoleReValidatio
 
 //ShowResultRule shows violated rules. If the filter condition (teamID, cloudID in this case) is valid,
 //rules will be filtered. Otherwise return all violation rules under this user account.
-func (c *Client) ShowResultRule(teamID, cloudID, level string) ([]*client.ResultRule, error) {
+func (c *Client) ShowResultRule(teamID, cloudID, level, provider string) ([]*client.ResultRule, error) {
 	//TODO
 	ctx := NewContext()
 	clt, err := c.MakeClient()
@@ -240,7 +240,7 @@ func (c *Client) ShowResultRule(teamID, cloudID, level string) ([]*client.Result
 		return nil, err
 	}
 
-	result, err := clt.ShowResultRule(ctx, teamID, cloudID, level)
+	result, err := clt.ShowResultRule(ctx, teamID, cloudID, level, provider)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/coreo/client.go
+++ b/pkg/coreo/client.go
@@ -39,7 +39,7 @@ func (c *Client) Option(opts ...Option) *Client {
 
 //MakeClient make client method
 func (c *Client) MakeClient() (*client.Client, error) {
-	return client.MakeClient(c.opts.apiKey, c.opts.secretKey, c.opts.host)
+	return client.MakeClient(c.opts.refreshToken, c.opts.host)
 }
 
 //ListTeams get list of teams

--- a/pkg/coreo/option.go
+++ b/pkg/coreo/option.go
@@ -23,9 +23,8 @@ import (
 type Option func(*options)
 
 type options struct {
-	host      string
-	apiKey    string
-	secretKey string
+	host         string
+	refreshToken string
 }
 
 // Host specifies the host address of the Coreo API server.
@@ -35,17 +34,10 @@ func Host(host string) Option {
 	}
 }
 
-//APIKey specifies the apiKey of the Coreo API server request.
-func APIKey(apiKey string) Option {
+//RefreshToken specifies the refreshToken of the Coreo API server request.
+func RefreshToken(refreshToken string) Option {
 	return func(opts *options) {
-		opts.apiKey = apiKey
-	}
-}
-
-// SecretKey specifies the secretKey of the Coreo API server request.
-func SecretKey(secretKey string) Option {
-	return func(opts *options) {
-		opts.secretKey = secretKey
+		opts.refreshToken = refreshToken
 	}
 }
 


### PR DESCRIPTION
1. Change rule reception to streaming
2. Allow environment and tags update for cloud update command
3. cloud update command supports Azure
4. Always pass filters to webapp backend(webapp should also check whether filter is undefined)
5. Pass filter to webapp backend rather than do filter locally
6. teamID is a required parameter for getting violations either by rules or objects now
7. Enable provider filter for getting rules
8. Flatten teamInfo for pretty print violating objects