### PR TITLE
PLA-9591 Send teamId to create a cloud account

### DIFF
--- a/client/cloudAccount.go
+++ b/client/cloudAccount.go
@@ -77,6 +77,7 @@ type CloudInfo struct {
 	Tags                []string `json:"tags,omitempty"`
 	IsValid             bool     `json:"isValid"`
 	LastValidationCheck string   `json:"lastValidationCheck"`
+	TeamID              string   `json:"teamId"`
 }
 
 // CloudPayLoad ...
@@ -261,6 +262,7 @@ func (c *Client) CreateCloudAccount(ctx context.Context, input *CreateCloudAccou
 					ApplicationID:  input.ApplicationID,
 					DirectoryID:    input.DirectoryID,
 					SubscriptionID: input.SubscriptionID,
+					TeamID:         input.TeamID,
 				},
 			}
 			if input.Environment != "" {

--- a/client/cloudAccount.go
+++ b/client/cloudAccount.go
@@ -180,6 +180,7 @@ func (c *Client) sendCloudCreateRequest(ctx context.Context, input *sendCloudCre
 	cloudAccount := &CloudAccount{}
 	cloudPayLoad := CloudPayLoad{
 		CloudInfo: input.CloudInfo,
+		TeamID:    input.TeamID,
 	}
 
 	jsonStr, err := json.Marshal(cloudPayLoad)


### PR DESCRIPTION
Creating a cloud account requires a team id.  We need to add the teamID to the input struct, as well as populate it on the CloudPayload struct.  Unfortunately, now it is defined in two places, because of (it looks like) a hack put in place to get around something in the webapp.  We should look into removing `TeamID` from the `CloudPayload` struct in the future.