### PR TITLE
Prevent CLI from overriding the project ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Use CLI to...
 
 ### OSX
 
-Download `vss` from [https://github.com/CloudCoreo/cli/releases/download/v0.0.48/vss_darwin_amd64](https://github.com/CloudCoreo/cli/releases/download/v0.0.48/vss_darwin_amd64)
+Download `vss` from [https://github.com/CloudCoreo/cli/releases/download/v0.0.49/vss_darwin_amd64](https://github.com/CloudCoreo/cli/releases/download/v0.0.49/vss_darwin_amd64)
 
 ```sh
  mkdir vss && cd vss
- wget -q -O vss https://github.com/CloudCoreo/cli/releases/download/v0.0.48/vss_darwin_amd64
+ wget -q -O vss https://github.com/CloudCoreo/cli/releases/download/v0.0.49/vss_darwin_amd64
  chmod +x vss
  export PATH=$PATH:${PWD}   # Add current dir where vss has been downloaded to
  vss
@@ -31,11 +31,11 @@ Download `vss` from [https://github.com/CloudCoreo/cli/releases/download/v0.0.48
 
 ### Linux
 
-Download `vss` from [https://github.com/CloudCoreo/cli/releases/download/v0.0.48/vss_linux_amd64](https://github.com/CloudCoreo/cli/releases/download/v0.0.48/vss_linux_amd64)
+Download `vss` from [https://github.com/CloudCoreo/cli/releases/download/v0.0.49/vss_linux_amd64](https://github.com/CloudCoreo/cli/releases/download/v0.0.49/vss_linux_amd64)
 
 ```sh
  mkdir vss && cd vss
- wget -q -O vss https://github.com/CloudCoreo/cli/releases/download/v0.0.48/vss_linux_amd64
+ wget -q -O vss https://github.com/CloudCoreo/cli/releases/download/v0.0.49/vss_linux_amd64
  chmod +x vss
  export PATH=$PATH:${PWD}   # Add current dir where vss has been downloaded to
  vss
@@ -43,7 +43,7 @@ Download `vss` from [https://github.com/CloudCoreo/cli/releases/download/v0.0.48
 
 ### Windows
 
-Download `vss.exe` from [https://github.com/CloudCoreo/cli/releases/download/v0.0.48/vss_windows_amd64.exe](https://github.com/CloudCoreo/cli/releases/download/v0.0.48/vss_windows_amd64.exe)
+Download `vss.exe` from [https://github.com/CloudCoreo/cli/releases/download/v0.0.49/vss_windows_amd64.exe](https://github.com/CloudCoreo/cli/releases/download/v0.0.49/vss_windows_amd64.exe)
 
 ```
 C:\Users\Username\Downloads> rename vss_windows_amd64.exe vss.exe
@@ -126,7 +126,7 @@ You may use CLI to do scriptable onboarding with two commands:
  vss cloud add --name YOUR_NEW_ACCOUNT_NAME --role NAME_FOR_NEW_ROLE [--aws-profile PROFILE_NAME] [–aws-profile-path PROFILE_PATH] [--policy-arn YOUR_POLICY_ARN]  
  vss event setup --cloud-id YOUR_CLOUD_ID [--aws-profile PROFILE_NAME] [--aws-profile-path PROFILE_PATH] 
 ```
-team-id flag is not required from CLI release v0.0.48
+team-id flag is not required from CLI release v0.0.49
 ## Docs
 
 Get started with [VSS commands](docs/vss/vss.md), setup for [VSS bash completion](docs/bash-completion.md)
@@ -231,7 +231,7 @@ Configure CLI options
     * `vss configure list`
     
 #### team
-Manage Teams(These commands are deprecated from CLI version v0.0.48)
+Manage Teams(These commands are deprecated from CLI version v0.0.49)
 * add
     * Usage
         * `vss team add -n YOUR_NEW_TEAM_NAME -d YOUR_TEAM_DESCRIPTION [flags]`
@@ -284,7 +284,7 @@ Show violation results (Deprecated, please follow the link to swagger API doc 'h
         * `vss result rule --cloud-account-id YOUR_SECURITY_STATE_CLOUD_ACCOUNT_ID --severity "Low"`
         
 #### token
-Manage API Tokens(These commands are deprecated from CLI version v0.0.48, please use [CSP portal](https://console.cloud.vmware.com/csp/gateway/portal/#/user/tokens)) to manage your token)
+Manage API Tokens(These commands are deprecated from CLI version v0.0.49, please use [CSP portal](https://console.cloud.vmware.com/csp/gateway/portal/#/user/tokens)) to manage your token)
 * delete
     * Usage
         * `vss token delete --token-id YOUR_TOKEN_ID [flags]`

--- a/client/cloudAccount.go
+++ b/client/cloudAccount.go
@@ -54,6 +54,7 @@ type CreateCloudAccountInput struct {
 	DirectoryID    string
 	SubscriptionID string
 	Tags           string
+	CSPProjectID   string
 }
 
 //CloudInfo listed all info of cloud accounts
@@ -76,6 +77,7 @@ type CloudInfo struct {
 	Tags                []string `json:"tags,omitempty"`
 	IsValid             bool     `json:"isValid"`
 	LastValidationCheck string   `json:"lastValidationCheck"`
+	CSPProjectID        string   `json:"cspProjectId"`
 }
 
 type defaultID struct {
@@ -210,6 +212,7 @@ func (c *Client) CreateCloudAccount(ctx context.Context, input *CreateCloudAccou
 		DirectoryID:    input.DirectoryID,
 		SubscriptionID: input.SubscriptionID,
 		Environment:    input.Environment,
+		CSPProjectID:   input.CSPProjectID,
 	}
 	if input.Tags != "" {
 		cloudCreateInput.Tags = strings.Split(input.Tags, "|")
@@ -263,7 +266,7 @@ func (c *Client) UpdateCloudAccount(ctx context.Context, input *UpdateCloudAccou
 	if err != nil {
 		return nil, err
 	}
-	err = c.Do(ctx, "POST", fmt.Sprintf("cloudaccounts/%s/update", input.CloudID), bytes.NewBuffer(updateInfo), result)
+	err = c.Do(ctx, "PUT", fmt.Sprintf("cloudaccounts/%s", input.CloudID), bytes.NewBuffer(updateInfo), result)
 	if err != nil {
 		return nil, err
 	}
@@ -304,6 +307,7 @@ func (t *UpdateCloudAccountInput) toCloudInfo() *CloudInfo {
 		KeyValue:       t.KeyValue,
 		ApplicationID:  t.ApplicationID,
 		DirectoryID:    t.DirectoryID,
+		CSPProjectID:   t.CSPProjectID,
 	}
 
 	return cloudInfo
@@ -327,6 +331,7 @@ func (t *CloudAccount) toCloudInfo() *CloudInfo {
 		ApplicationID:  t.ApplicationID,
 		DirectoryID:    t.DirectoryID,
 		Tags:           t.Tags,
+		CSPProjectID:   t.CSPProjectID,
 	}
 	return cloudInfo
 }

--- a/client/cloudAccount_test.go
+++ b/client/cloudAccount_test.go
@@ -56,8 +56,8 @@ const CloudAccountsJSONPayload = `[
 			},
 			{
 				"ref": "update",
-				"method": "POST",
-				"href": "%s/cloudaccounts/cloudAccountID/update"
+				"method": "PUT",
+				"href": "%s/cloudaccounts/cloudAccountID"
 			},
 			{
 				"ref": "test",
@@ -72,7 +72,7 @@ const CloudAccountsJSONPayload = `[
 const RoleCreationInfoJSONPayload = `{
 		"accountId": "Fake-aws-account-id",
 		"externalId": "Fake-external-id",
-		"domain": "fake domain"
+		"domain": "fake domain"	
 	}`
 
 const CloudAccountJSONPayload = `{


### PR DESCRIPTION
The API treats an empty project as the 'default' project, therefore
assuming that a user wants to change the project whenever they
call an update. This PR ensures that the current project is pulled
from the remote site before being checked against the input
parameters.