### PR TITLE
PLA-21143: Add account to default project when project not specified and minor fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ install:
   - go get -u golang.org/x/lint/golint
 script:
   - go vet $(go list ./... | grep -v vendor)
+  - go test ./...
 before_deploy:
   - 'GOOS=linux GOARCH=amd64 go build --ldflags "-X main.version=$TRAVIS_TAG -X main.buildID=$TRAVIS_BUILD_NUMBER -X main.githash=$TRAVIS_COMMIT" -o vss_linux_amd64 github.com/CloudCoreo/cli/cmd'
   - 'GOOS=linux GOARCH=386 go build --ldflags "-X main.version=$TRAVIS_TAG -X main.buildID=$TRAVIS_BUILD_NUMBER -X main.githash=$TRAVIS_COMMIT" -o vss_linux_386 github.com/CloudCoreo/cli/cmd'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - "1.10"
+  - "1.15"
 gobuild_args: -ldflags "-X main.version=$TRAVIS_TAG -X main.buildID=$TRAVIS_BUILD_NUMBER -X main.githash=$TRAVIS_COMMIT"
 install:
   - go get github.com/mattn/goveralls

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -115,7 +115,7 @@ func TestDoTestSuite(t *testing.T) {
 
 func TestBuildRequest(t *testing.T) {
 
-	i := Interceptor(func(req *http.Request) error { return fmt.Errorf("Return error") })
+	i := Interceptor(func(req *http.Request) error { return fmt.Errorf("return error") })
 	c := newClient("http://test.com", WithInterceptor(i))
 	_, err := c.buildRequest("GET", "http://test.com", nil)
 

--- a/client/cloudAccount.go
+++ b/client/cloudAccount.go
@@ -217,6 +217,9 @@ func (c *Client) CreateCloudAccount(ctx context.Context, input *CreateCloudAccou
 	if input.Tags != "" {
 		cloudCreateInput.Tags = strings.Split(input.Tags, "|")
 	}
+	if input.CSPProjectID == "" {
+		cloudCreateInput.CSPProjectID = "default"
+	}
 	if input.Provider == "AWS" {
 		cloudCreateInput.ScanInterval = "Weekly"
 	} else if input.Provider == "Azure" {

--- a/client/cloudAccount_test.go
+++ b/client/cloudAccount_test.go
@@ -221,7 +221,7 @@ func TestCreateCloudAccountFailureCloudAccountNotCreated(t *testing.T) {
 	}
 	_, err := client.CreateCloudAccount(context.Background(), input)
 	assert.NotNil(t, err, "CreateCloudAccount should return error.")
-	assert.Equal(t, "Adding cloud account falied, you need to provide either rolearn and external id or new role name", err.Error())
+	assert.Equal(t, "Adding cloud account failed, you need to provide either rolearn and external id or new role name", err.Error())
 }
 
 func TestDeleteCloudAccountByIDSuccess(t *testing.T) {
@@ -272,7 +272,7 @@ func TestUpdateCloudAccountSuccess(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 	httpmock.RegisterResponder("GET", defaultAPIEndpoint+"/cloudaccounts/cloudAccountID", httpmock.NewStringResponder(http.StatusOK, createdCloudAccountJSONPayload))
-	httpmock.RegisterResponder("POST", defaultAPIEndpoint+"/cloudaccounts/cloudAccountID/update", httpmock.NewStringResponder(http.StatusOK, createdCloudAccountJSONPayload))
+	httpmock.RegisterResponder("PUT", defaultAPIEndpoint+"/cloudaccounts/cloudAccountID", httpmock.NewStringResponder(http.StatusOK, createdCloudAccountJSONPayload))
 	httpmock.RegisterResponder("POST", cspURL+cspResource, httpmock.NewStringResponder(http.StatusOK, refreshTokenJSONPayload))
 
 	client, _ := MakeClient("ApiKey", defaultAPIEndpoint)

--- a/client/content/common.go
+++ b/client/content/common.go
@@ -17,7 +17,7 @@ const (
 	ErrorFailedToDeleteCloudAccount = "Failed to delete cloud account with ID %s under team ID %s."
 
 	//ErrorMissingRoleInformation error
-	ErrorMissingRoleInformation = "Adding cloud account falied, you need to provide either rolearn and external id or new role name"
+	ErrorMissingRoleInformation = "Adding cloud account failed, you need to provide either rolearn and external id or new role name"
 
 	//ErrorNoTokensFound error
 	ErrorNoTokensFound = "No tokens found. To create a token use `coreo token add [flags]` command."

--- a/cmd/content/cloud.go
+++ b/cmd/content/cloud.go
@@ -70,10 +70,10 @@ Add a cloud account. The result would be shown as the following if successful.
 	//CmdCloudShowLong long description
 	CmdCloudShowLong = `Show a cloud account.`
 
-	//CmdCloudDeleteShort short desription
+	//CmdCloudDeleteShort short description
 	CmdCloudDeleteShort = "Delete a cloud account"
 
-	//CmdCloudDeleteLong long desription
+	//CmdCloudDeleteLong long description
 	CmdCloudDeleteLong = `Delete a cloud account.`
 
 	//CmdFlagCloudIDLong flag
@@ -107,7 +107,7 @@ Add a cloud account. The result would be shown as the following if successful.
 	CmdFlagIgnoreMissingTrailsDescription = "CLI will continue on event steam setup even if CloudTrail is not enabled in all regions"
 
 	//CmdFlagDuration is the duration of session keys for cloud scan command
-	CmdFlagDuration = "duartion"
+	CmdFlagDuration = "duration"
 
 	//CmdFlagDurationDescription describes the flag duration
 	CmdFlagDurationDescription = "The duration for session in seconds"

--- a/cmd/util/viper.go
+++ b/cmd/util/viper.go
@@ -34,7 +34,7 @@ func SaveViperConfig() error {
 
 	b, err := yaml.Marshal(all)
 	if err != nil {
-		return fmt.Errorf("Panic while encoding into YAML format.")
+		return fmt.Errorf("panic while encoding into YAML format")
 	}
 	if _, err := f.WriteString(string(b)); err != nil {
 		return err

--- a/pkg/lint/support/message_test.go
+++ b/pkg/lint/support/message_test.go
@@ -60,18 +60,18 @@ func TestRunLinterRule(t *testing.T) {
 }
 
 func TestMessage(t *testing.T) {
-	m := Message{ErrorSev, "config.yaml", errors.New("Foo")}
-	if m.Error() != "[ERROR] config.yaml: Foo" {
+	m := Message{ErrorSev, "config.yaml", errors.New("foo")}
+	if m.Error() != "[ERROR] config.yaml: foo" {
 		t.Errorf("Unexpected output: %s", m.Error())
 	}
 
-	m = Message{WarningSev, "config.yaml", errors.New("Bar")}
-	if m.Error() != "[WARNING] config.yaml: Bar" {
+	m = Message{WarningSev, "config.yaml", errors.New("bar")}
+	if m.Error() != "[WARNING] config.yaml: bar" {
 		t.Errorf("Unexpected output: %s", m.Error())
 	}
 
-	m = Message{InfoSev, "config.yaml", errors.New("FooBar")}
-	if m.Error() != "[INFO] config.yaml: FooBar" {
+	m = Message{InfoSev, "config.yaml", errors.New("foobar")}
+	if m.Error() != "[INFO] config.yaml: foobar" {
 		t.Errorf("Unexpected output: %s", m.Error())
 	}
 }


### PR DESCRIPTION
This pull request fix a bug where cloud accounts without a project id specified couldn't be added.
It also upgrades the goland version to 1.15, changes dep to go modules and minor typos and test fixes.